### PR TITLE
chore(dev): CORS par défaut en dev + expose endpoints JWT dans urls r…

### DIFF
--- a/backend/calendar_project/settings.py
+++ b/backend/calendar_project/settings.py
@@ -102,6 +102,13 @@ CORS_ALLOWED_ORIGINS = _split_env("CORS_ALLOWED_ORIGINS")  # p.ex. https://cal.m
 CSRF_TRUSTED_ORIGINS = _split_env("CSRF_TRUSTED_ORIGINS")  # p.ex. https://cal.mon-site.ca, https://cal-api.mon-site.ca
 CORS_ALLOW_CREDENTIALS = True  # utile si un jour cookies/headers auth inter-sites
 
+# Defaults CORS pratiques en DEV si rien n'est passé par l'env
+if DEBUG and not CORS_ALLOWED_ORIGINS:
+    CORS_ALLOWED_ORIGINS = [
+        "http://localhost:5174",
+        "http://127.0.0.1:5174",
+    ]
+
 # --- Reverse proxy TLS (Apache) : indique à Django que la requête est en HTTPS
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/backend/calendar_project/urls.py
+++ b/backend/calendar_project/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("calendar_api.urls")),
+    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]


### PR DESCRIPTION
- Ajoute des valeurs par défaut CORS en DEV (localhost/127.0.0.1:5174) si env vide
- Expose /api/token/ et /api/token/refresh/ dans urls racine
- Impact: aucun changement de prod si variables d’env correctement définies
- Testé: login/logout frontend OK, liste des calendriers OK
